### PR TITLE
Add keep_servo_down_after_lane_load

### DIFF
--- a/Klipper_Stuff/klippy_module/trad_rack.py
+++ b/Klipper_Stuff/klippy_module/trad_rack.py
@@ -223,6 +223,9 @@ class TradRack:
         self.save_active_lane = config.getboolean("save_active_lane", True)
         self.log_bowden_lengths = config.getboolean("log_bowden_lengths", False)
 
+
+        self.keep_servo_down_after_lane_load = config.getboolean("keep_servo_down_after_lane_load", False)
+
         # other variables
         self.toolhead = None
         self.curr_lane = None  # which lane the selector is positioned at
@@ -1195,8 +1198,9 @@ class TradRack:
         # reset filament driver position
         self._reset_fil_driver()
 
-        # raise servo
-        self._raise_servo()
+        if not self.keep_servo_down_after_lane_load:
+            # raise servo
+            self._raise_servo()
 
         if user_load:
             self.gcode.respond_info("Load complete")

--- a/docs/klipper/Config_Reference.md
+++ b/docs/klipper/Config_Reference.md
@@ -240,6 +240,10 @@ toolhead_unload_length:
 #   Gcode command template that is run whenever the TR_RESUME command
 #   needs to resume the print. The default is to run the RESUME
 #   gcode command.
+#keep_servo_down_after_lane_load: False
+#   If set to True, after loading filament into a lane the servo is kept
+#   down to hold the filament in place.
+
 ```
 
 ## Additional sections


### PR DESCRIPTION
Added `keep_servo_down_after_lane_load` config, this will keep the servo down after loading a lane so the filament is held and doesn't move out if the bowden or spool is moved right after loading.