### PR TITLE
Codify Conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{py,sh}]
+indent_style = space
+indent_size = 4

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "yzhang.markdown-all-in-one",
+    "EditorConfig.EditorConfig",
+    "dannymcgee.klipper"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "editor.rulers": [
         70, 80, 120
-    ]
+    ],
+    "markdown.extension.toc.levels": "2..6",
+    "markdown.extension.toc.updateOnSave": true
 }


### PR DESCRIPTION
- Added extension recommendations for vscode
- added .editorconfig to codify formatting support for most other editors
- added recommendation for klipper extension to beef up syntax highlighting for `.cfg` files

I set the settings for the TOC to use `2..6`, which will cause all TOC create/updates to ignore the top level heading, and then will create an entry for H2 - H6.